### PR TITLE
Adjustments from Eta-2 to Eta-3 (Balancing/Ease)

### DIFF
--- a/src/main/java/com/startechnology/start_core/machine/boosting/BoostedPlasmaTurbine.java
+++ b/src/main/java/com/startechnology/start_core/machine/boosting/BoostedPlasmaTurbine.java
@@ -40,7 +40,7 @@ public class BoostedPlasmaTurbine extends LargeTurbineMachine {
     protected static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(
             BoostedPlasmaTurbine.class, LargeTurbineMachine.MANAGED_FIELD_HOLDER);
 
-    private static final int SUPREME_TURBINE_TIER = GTValues.IV;
+    private static final int SUPREME_TURBINE_TIER = GTValues.UHV;
     private static final int NYINSANE_TURBINE_TIER = GTValues.UIV;
 
     private Integer tier;
@@ -73,9 +73,9 @@ public class BoostedPlasmaTurbine extends LargeTurbineMachine {
     private double getBoostingBonus() {
         switch(this.tier) {
             case SUPREME_TURBINE_TIER:
-                return isActiveBoosting ? 2.5 : 1.5;
+                return isActiveBoosting ? 2 : 1.25;
             case NYINSANE_TURBINE_TIER:
-                return isActiveBoosting ? 4 : 2;
+                return isActiveBoosting ? 3 : 1.5;
             default: 
                 return 1;
         }
@@ -85,9 +85,9 @@ public class BoostedPlasmaTurbine extends LargeTurbineMachine {
     private double getNonBoostingBonus() {
         switch(this.tier) {
             case SUPREME_TURBINE_TIER:
-                return 0.75;
+                return 0.9;
             case NYINSANE_TURBINE_TIER:
-                return 0.5;
+                return 0.8;
             default: 
                 return 1;
         }
@@ -97,9 +97,9 @@ public class BoostedPlasmaTurbine extends LargeTurbineMachine {
     private GTRecipe getPassiveBoostingRecipe() {
         switch(this.tier) {
             case SUPREME_TURBINE_TIER:
-                return GTRecipeBuilder.ofRaw().inputFluids(WS2_FLUID.getFluid(5000)).buildRawRecipe();
+                return GTRecipeBuilder.ofRaw().inputFluids(WS2_FLUID.getFluid(2000)).buildRawRecipe();
             case NYINSANE_TURBINE_TIER:
-                return GTRecipeBuilder.ofRaw().inputFluids(WS2_FLUID.getFluid(9600)).buildRawRecipe();
+                return GTRecipeBuilder.ofRaw().inputFluids(WS2_FLUID.getFluid(5000)).buildRawRecipe();
             default: 
                 return GTRecipeBuilder.ofRaw().buildRawRecipe();
         }
@@ -109,9 +109,9 @@ public class BoostedPlasmaTurbine extends LargeTurbineMachine {
     private GTRecipe getActiveBoostingRecipe() {
         switch(this.tier) {
             case SUPREME_TURBINE_TIER:
-                return GTRecipeBuilder.ofRaw().inputFluids(SS_HE3_FLUID.getFluid(1000)).buildRawRecipe();
+                return GTRecipeBuilder.ofRaw().inputFluids(SS_HE3_FLUID.getFluid(2500)).buildRawRecipe();
             case NYINSANE_TURBINE_TIER:
-                return GTRecipeBuilder.ofRaw().inputFluids(BEC_OG_FLUID.getFluid(1800)).buildRawRecipe();
+                return GTRecipeBuilder.ofRaw().inputFluids(BEC_OG_FLUID.getFluid(800)).buildRawRecipe();
             default: 
                 return GTRecipeBuilder.ofRaw().buildRawRecipe();
         }

--- a/src/main/java/com/startechnology/start_core/machine/steam/StarTSteamParallelMultiblockMachine.java
+++ b/src/main/java/com/startechnology/start_core/machine/steam/StarTSteamParallelMultiblockMachine.java
@@ -48,8 +48,8 @@ public class StarTSteamParallelMultiblockMachine extends WorkableMultiblockMachi
 
     public int maxParallels = 6;
 
-    // if in millibuckets, this is 4.0, Meaning 4mb of steam -> 1 EU
-    public static final double CONVERSION_RATE = 4.0;
+    // if in millibuckets, this is 3.0, Meaning 3mb of steam -> 1 EU
+    public static final double CONVERSION_RATE = 3.0;
 
     public StarTSteamParallelMultiblockMachine(IMachineBlockEntity holder, Object... args) {
         super(holder);

--- a/src/main/java/com/startechnology/start_core/recipe/StarTRecipeModifiers.java
+++ b/src/main/java/com/startechnology/start_core/recipe/StarTRecipeModifiers.java
@@ -62,7 +62,7 @@ public class StarTRecipeModifiers {
 
         double timesScaled = Math.floor(Math.max(0.0, (hellforgeTemp - recipeTemp) / 450.0));
         int hellforgeParallels = (int) Math.pow(2.0, timesScaled);
-
+        
         int maxPossibleParallels = ParallelLogic.getParallelAmountFast(machine, recipe, hellforgeParallels);
 
         // Runs largest 2^n parallels that it can. 1,2,4,8,16,etc.
@@ -70,8 +70,34 @@ public class StarTRecipeModifiers {
             .modifyAllContents(ContentModifier.multiplier(maxPossibleParallels))
             .parallels(maxPossibleParallels)
             .build();
+        }
+
+    public static final RecipeModifier BULK_PROCESSING = StarTRecipeModifiers::bulkThroughputProcessing;
+
+    public static ModifierFunction bulkThroughputProcessing(MetaMachine machine, GTRecipe recipe) {
+        // Bulks at 4n:3n up to bulkLimit = 4n
+        int bulkLimit = 64;
+
+        int maxBulking = ParallelLogic.getParallelAmountFast(machine, recipe, bulkLimit);
+
+        double timesBulkingApplied = Math.floor(Math.max(0.0, (maxBulking / 4)));
+
+        int thoughputBulkingApplied = (int) timesBulkingApplied * 4;
+        int durationBulkingApplied = (int) timesBulkingApplied * 3;
+
+        if (timesBulkingApplied >= 1) {
+       
+        return ModifierFunction.builder()
+            .modifyAllContents(ContentModifier.multiplier(thoughputBulkingApplied)) 
+            .durationMultiplier(durationBulkingApplied)
+            .parallels(thoughputBulkingApplied)    
+            .build();
 
         }
+        
+        return ModifierFunction.IDENTITY;
+  
+    }
 
     public static final RecipeModifier EBF_OVERCLOCK = GTRecipeModifiers::ebfOverclock;
 


### PR DESCRIPTION
- [ ] Bulking Added as a Recipe Modifier
- 4n:3n modifier, runs largest 4n throughput up till 4n=64 at rates of n=2^(N), corresponding time increase is 3n
- ~75% thoughput increase when ran currently for all >4 recipes
- Possible Adjustments to 4n=16 as min (tbd)
- [ ] StarTSteamParallels Adjusted
- 3mb/eu rather than 4mb/eu
- [ ] Boosted Turbines Adjusted
- SPT Changed to UHV indicator
- Lubricant boosting now -10/25, -20/50 rather than the prior -25/50, -50/100, Consumptions rates are now 2000 and 5000 rather than 5000 and 9600
- Coolant boosting adjusted to be 125/200, 150/300 compared to the prior 150/250, 200/400, SS-He3 cost increased and BEC-Og more reasonable
- SPT=>NPT delta from 3.2x=>3x
- [ ] Fix Fusion Casings not being breakable
- ...