### PR TITLE
Applies network when `TOOL_DREAM_COPY_ITEM` is in offhand

### DIFF
--- a/src/main/java/com/startechnology/start_core/item/StarTItems.java
+++ b/src/main/java/com/startechnology/start_core/item/StarTItems.java
@@ -56,7 +56,10 @@ public class StarTItems {
     public static final ItemEntry<ComponentItem> TOOL_DREAM_COPY_ITEM = START_REGISTRATE.item("lucinducer", ComponentItem::create)
         .lang("Lucinducer")
         .onRegister(attach(new StarTDreamCopyBehaviour()))
-        .onRegister(attach(new TooltipBehavior(lines -> lines.add(Component.translatable("item.start_core.lucinducer.tooltip")))))
+        .onRegister(attach(new TooltipBehavior(lines -> {
+            lines.add(Component.translatable("item.start_core.lucinducer.tooltip1"));
+            lines.add(Component.translatable("item.start_core.lucinducer.tooltip2"));
+        })))
         .register();
 
     public static final ItemEntry<ComponentItem> MECHANICAL_MEMORY_CARD = START_REGISTRATE.item("mechanical_memory_card", ComponentItem::create)

--- a/src/main/java/com/startechnology/start_core/machine/dreamlink/StarTDreamLinkCover.java
+++ b/src/main/java/com/startechnology/start_core/machine/dreamlink/StarTDreamLinkCover.java
@@ -45,8 +45,6 @@ public class StarTDreamLinkCover extends CoverBehavior implements IStarTDreamLin
     private TickableSubscription addTickSubscription;
     private UUID ownerUUID;
 
-    private ItemStack dreamItem = new ItemStack(StarTItems.TOOL_DREAM_COPY_ITEM);
-
     public StarTDreamLinkCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier, int amperage) {
         super(definition, coverHolder, attachedSide);
         this.network = IStarTDreamLinkNetworkMachine.DEFAULT_NETWORK;
@@ -62,7 +60,7 @@ public class StarTDreamLinkCover extends CoverBehavior implements IStarTDreamLin
 
         var playerOffhandItem = player.getOffhandItem();
 
-        if (dreamItem.is(playerOffhandItem.getItem())) {
+        if (playerOffhandItem.is(StarTItems.TOOL_DREAM_COPY_ITEM.asItem())) {
             onDreamCopyUse(player, playerOffhandItem);
         }
     }

--- a/src/main/java/com/startechnology/start_core/machine/dreamlink/StarTDreamLinkCover.java
+++ b/src/main/java/com/startechnology/start_core/machine/dreamlink/StarTDreamLinkCover.java
@@ -1,8 +1,5 @@
 package com.startechnology.start_core.machine.dreamlink;
 
-import java.util.Objects;
-import java.util.UUID;
-
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
@@ -13,25 +10,27 @@ import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.cover.IUICover;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.machine.feature.IExplosionMachine;
-import com.lowdragmc.lowdraglib.gui.widget.DraggableScrollableWidgetGroup;
-import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
-import com.lowdragmc.lowdraglib.gui.widget.TextFieldWidget;
-import com.lowdragmc.lowdraglib.gui.widget.Widget;
-import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
+import com.lowdragmc.lowdraglib.gui.widget.*;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import com.startechnology.start_core.api.capability.IStarTDreamLinkNetworkMachine;
 import com.startechnology.start_core.api.capability.IStarTDreamLinkNetworkRecieveEnergy;
 import com.startechnology.start_core.api.capability.IStarTGetMachineUUIDSafe;
 import com.startechnology.start_core.api.dreamlink.IStarTDreamCopyInteractable;
-
+import com.startechnology.start_core.item.StarTItems;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.UUID;
+
 
 public class StarTDreamLinkCover extends CoverBehavior implements IStarTDreamLinkNetworkRecieveEnergy, IStarTDreamCopyInteractable, IUICover {
     
@@ -46,11 +45,26 @@ public class StarTDreamLinkCover extends CoverBehavior implements IStarTDreamLin
     private TickableSubscription addTickSubscription;
     private UUID ownerUUID;
 
+    private ItemStack dreamItem = new ItemStack(StarTItems.TOOL_DREAM_COPY_ITEM);
+
     public StarTDreamLinkCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier, int amperage) {
         super(definition, coverHolder, attachedSide);
         this.network = IStarTDreamLinkNetworkMachine.DEFAULT_NETWORK;
         this.tier = tier;
         this.amperage = amperage;
+    }
+
+    @Override
+    public void onAttached(ItemStack itemStack, @Nullable ServerPlayer player) {
+        super.onAttached(itemStack, player);
+
+        if (player == null) return;
+
+        var playerOffhandItem = player.getOffhandItem();
+
+        if (dreamItem.is(playerOffhandItem.getItem())) {
+            onDreamCopyUse(player, playerOffhandItem);
+        }
     }
 
     @Override

--- a/src/main/java/com/startechnology/start_core/machine/dreamlink/StarTDreamLinkHatchPartMachine.java
+++ b/src/main/java/com/startechnology/start_core/machine/dreamlink/StarTDreamLinkHatchPartMachine.java
@@ -1,35 +1,22 @@
 package com.startechnology.start_core.machine.dreamlink;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.fancy.FancyMachineUIWidget;
-import com.gregtechceu.gtceu.api.gui.fancy.IFancyTooltip;
-import com.gregtechceu.gtceu.api.gui.fancy.TooltipsPanel;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
-import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
-import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
+import com.gregtechceu.gtceu.api.machine.feature.IMachineLife;
 import com.gregtechceu.gtceu.api.machine.multiblock.part.TieredIOPartMachine;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
-import com.lowdragmc.lowdraglib.gui.editor.configurator.IConfigurableWidget;
 import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
-import com.lowdragmc.lowdraglib.gui.widget.ComponentPanelWidget;
-import com.lowdragmc.lowdraglib.gui.widget.DraggableScrollableWidgetGroup;
-import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
-import com.lowdragmc.lowdraglib.gui.widget.TextFieldWidget;
-import com.lowdragmc.lowdraglib.gui.widget.Widget;
-import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
+import com.lowdragmc.lowdraglib.gui.widget.*;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import com.startechnology.start_core.api.capability.IStarTDreamLinkNetworkMachine;
 import com.startechnology.start_core.api.capability.IStarTDreamLinkNetworkRecieveEnergy;
 import com.startechnology.start_core.api.capability.IStarTGetMachineUUIDSafe;
 import com.startechnology.start_core.api.capability.StarTNotifiableDreamLinkContainer;
-
+import com.startechnology.start_core.item.StarTItems;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.ChatFormatting;
@@ -41,11 +28,16 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
 
-public class StarTDreamLinkHatchPartMachine extends TieredIOPartMachine implements IStarTDreamLinkNetworkMachine, IStarTDreamLinkNetworkRecieveEnergy {
+import java.util.List;
+import java.util.Objects;
+
+public class StarTDreamLinkHatchPartMachine extends TieredIOPartMachine implements IStarTDreamLinkNetworkMachine, IStarTDreamLinkNetworkRecieveEnergy, IMachineLife {
 
     /*
      * As far as i can understand, the Managed Field Holder allows this class
@@ -161,10 +153,23 @@ public class StarTDreamLinkHatchPartMachine extends TieredIOPartMachine implemen
     public void setNetwork(String network) {
         this.network = network;
     }
-
+    
     @Override
     public String getNetwork() {
         return this.network;
+    }
+
+    @Override
+    public void onMachinePlaced(@Nullable LivingEntity player, ItemStack stack) {
+        IMachineLife.super.onMachinePlaced(player, stack);
+
+        if (player == null) return;
+
+        var playerOffhandItem = player.getOffhandItem();
+
+        if (playerOffhandItem.is(StarTItems.TOOL_DREAM_COPY_ITEM.asItem())) {
+            onDreamCopyUse((Player) player, playerOffhandItem);
+        }
     }
 
     @Override
@@ -178,7 +183,6 @@ public class StarTDreamLinkHatchPartMachine extends TieredIOPartMachine implemen
         }
         return InteractionResult.SUCCESS;
     }
-
 
     @Override
     public final InteractionResult onDreamCopyUse(Player player, ItemStack copyItem) {

--- a/src/main/resources/assets/start_core/lang/en_us.json
+++ b/src/main/resources/assets/start_core/lang/en_us.json
@@ -379,7 +379,8 @@
   "start_core.abyssal_containment_room.not_provided_fluids": "Isolation fluids not provided",
   "start_core.abyssal_containment_room.provided_fluids": "Provided isolation fluids",
 
-  "item.start_core.lucinducer.tooltip": "§7Copies Dream-Link Network information",
+  "item.start_core.lucinducer.tooltip1": "§7Copies and applies Dream-Link network information.",
+  "item.start_core.lucinducer.tooltip2": "§7While held offhand, the stored network will be applied to any placed Dream-Link Hatch or Cover.",
   "item.start_core.lucinducer": "Lucinducer",
 
   "item.start_core.mechanical_memory_card.tooltip": "§7Allows you to copy miscellaneous machines information. Supported: ",


### PR DESCRIPTION
When having a `TOOL_DREAM_COPY_ITEM` in your offhand, while placing a cover it applies the network directly to the cover or hatch.

Implements: https://discord.com/channels/1177211394039484477/1416169196697686257