### PR TITLE
Fix BacterialRunicMutatorLogic to use the new affinities when mutating to a new type

### DIFF
--- a/src/main/java/com/startechnology/start_core/recipe/logic/BacterialRunicMutatorLogic.java
+++ b/src/main/java/com/startechnology/start_core/recipe/logic/BacterialRunicMutatorLogic.java
@@ -185,7 +185,7 @@ public class BacterialRunicMutatorLogic implements ICustomRecipeLogic {
         Fluid newSuperFluid = StarTBacteriaBehaviour.getBacteriaBehaviour(output).getSuperfluid().getFluid();
 
         StarTBacteriaStats newStats = new StarTBacteriaStats(production, metabolism, mutability,
-                possibleAffinityFluids.get(0), possibleAffinityFluids.get(1), possibleAffinityFluids.get(2), newSuperFluid
+                possibleNewAffinities.get(0), possibleNewAffinities.get(1), possibleNewAffinities.get(2), newSuperFluid
         );
         StarTBacteriaManager.writeBacteriaStatsToItem(output.getOrCreateTag(), newStats);
 


### PR DESCRIPTION
Fixes https://discord.com/channels/1177211394039484477/1409013650676650169 and https://discord.com/channels/1177211394039484477/1443068831772971019