### PR TITLE
build: Remove allow enhanced class redefinition flag for better JDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-# Star Technology Core 
+# Star Technology: Beyond Core 
 
-This repository contains the Core Mod for Star Technology, adding new unique things to Gregtech Modern for the modpack.
+This repository contains the Core Mod for Star Technology: Beyond, adding new unique things to Gregtech Modern for the modpack.
+
+See the notice in src/main/resources/META-INF/NOTICE.md for more information.

--- a/build.gradle
+++ b/build.gradle
@@ -51,9 +51,6 @@ loom {
             mod(mod_id)
         }
     }
-    runConfigs.named("client").configure {
-        vmArg("-XX:+AllowEnhancedClassRedefinition")
-    }
     runConfigs.named("data").configure {
         programArg("--existing=" + file("src/main/resources").absolutePath)
         programArg("--existing-mod=gtceu")

--- a/src/main/resources/META-INF/NOTICE.md
+++ b/src/main/resources/META-INF/NOTICE.md
@@ -1,0 +1,20 @@
+# Notice
+
+This project is a modified fork of **Star Technology Core**.
+
+## Original Project
+
+Original project: https://github.com/StarT-Dev-Team/StarT-Core.
+Original copyright: Copyright © StarT Dev Team and contributors. 
+Original licence: GNU Lesser General Public License version 3.
+
+## Modified Project
+
+Modifications copyright © 2026 Star Technology: Beyond Development Team. 
+This modified version is distributed under the GNU Lesser General Public License version 3.
+
+Source code for this modified version, including the version corresponding to distributed builds, is available at: https://github.com/Star-Technology-Beyond/StarT-Beyond-Core.
+For a list of changes and modifications to the original project, see the Git commit history in the repository.
+
+This program is distributed without any warranty, to the extent permitted by law.
+See the included LGPLv3 licence text for details.


### PR DESCRIPTION
- The AllowEnhancedClassRedefinition is not supported by all jdks and may lead to build failure, we remove this to better support all java runtimes for the development process in general.

The downside is hot reloading maybe reduced, but for individuals interested in that, they may maintain a version of the build.gradle with AllowEnhancedClassRedefinition.