### PR TITLE
Crash if not using the fork

### DIFF
--- a/src/main/java/com/startechnology/start_core/StarTCore.java
+++ b/src/main/java/com/startechnology/start_core/StarTCore.java
@@ -100,6 +100,7 @@ public class StarTCore {
         if (gtceu == null) {
             LOGGER.error("GTm is not installed! Please install it!");
             // let forge handle the crash
+            return;
         }
 
         Object forkProperty = gtceu.getModInfo().getModProperties().get("isStarTFork");

--- a/src/main/java/com/startechnology/start_core/StarTCore.java
+++ b/src/main/java/com/startechnology/start_core/StarTCore.java
@@ -40,6 +40,8 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -61,6 +63,8 @@ public class StarTCore {
 
     public StarTCore(FMLJavaModLoadingContext context) {
         IEventBus modEventBus = context.getModEventBus();
+
+        checkGTMCompatibility();
 
         StarTConfig.init();
 
@@ -89,6 +93,20 @@ public class StarTCore {
         UltimineFramedBlocksPlugin.init();
 
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> StarTCoreClient::init);
+    }
+
+    private void checkGTMCompatibility() {
+        ModContainer gtceu = ModList.get().getModContainerById("gtceu").orElse(null);
+        if (gtceu == null) {
+            LOGGER.error("GTm is not installed! Please install it!");
+            // let forge handle the crash
+        }
+
+        Object forkProperty = gtceu.getModInfo().getModProperties().get("isStarTFork");
+
+        if (!Boolean.TRUE.equals(forkProperty)) {
+            throw new IllegalStateException("StarT Core requires the StarT GTm fork to be installed!");
+        }
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/startechnology/start_core/StarTCore.java
+++ b/src/main/java/com/startechnology/start_core/StarTCore.java
@@ -105,7 +105,7 @@ public class StarTCore {
         Object forkProperty = gtceu.getModInfo().getModProperties().get("isStarTFork");
 
         if (!Boolean.TRUE.equals(forkProperty)) {
-            throw new IllegalStateException("StarT Core requires the StarT GTm fork to be installed!");
+            throw new IllegalStateException("StarT Core requires the StarT GTm fork to be installed! If your instance contains the regular GTm mod, please uninstall it!");
         }
     }
 


### PR DESCRIPTION
StarT Core will now check that the `gtceu` mod contains the `isStarTFork` boolean property. If the property is missing, the game will crash and the message "StarT Core requires the StarT GTm fork to be installed!" message will be displayed. Fix fixes the issue when a player installs a GTm addon and that installs GTm adjacently the game would crash and the player would be confused as to why it was crashing.