### PR TITLE
Fix some Theta 1 exploits

### DIFF
--- a/src/main/java/com/startechnology/start_core/machine/dreamlink/StarTDreamLinkCover.java
+++ b/src/main/java/com/startechnology/start_core/machine/dreamlink/StarTDreamLinkCover.java
@@ -8,8 +8,12 @@ import com.gregtechceu.gtceu.api.capability.IEnergyContainer;
 import com.gregtechceu.gtceu.api.cover.CoverBehavior;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.cover.IUICover;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.machine.feature.IExplosionMachine;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
+import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
 import com.lowdragmc.lowdraglib.gui.widget.*;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
@@ -56,6 +60,16 @@ public class StarTDreamLinkCover extends CoverBehavior
         this.network = IStarTDreamLinkNetworkMachine.DEFAULT_NETWORK;
         this.tier = tier;
         this.amperage = amperage;
+    }
+
+    @Override
+    public boolean canAttach() {
+        if (!super.canAttach()) return false;
+        var machine = MetaMachine.getMachine(this.coverHolder.getLevel(), this.coverHolder.getPos());
+        if (machine == null) return false;
+        // disallow attaching dreamlink covers to multiblock parts or controllers, and machines without energy traits
+        return !(machine instanceof IMultiPart) && !(machine instanceof IMultiController) &&
+                machine.getTraits().stream().anyMatch(t -> t instanceof IEnergyContainer);
     }
 
     @Override

--- a/src/main/java/com/startechnology/start_core/machine/hellforge/StarTHellForgeMachine.java
+++ b/src/main/java/com/startechnology/start_core/machine/hellforge/StarTHellForgeMachine.java
@@ -75,15 +75,17 @@ public class StarTHellForgeMachine extends WorkableElectricMultiblockMachine imp
     @Override
     public void onStructureFormed() {
         super.onStructureFormed();
-        this.isWorking = false;
-        this.startHeatLoss = true;
-        this.temperatureChanged();
+        isWorking = false;
+        startHeatLoss = true;
+        temperature = baseTemperature;
+        temperatureChanged();
     }
 
     @Override
     public void onStructureInvalid() {
         super.onStructureInvalid();
-        this.isWorking = false;
+        isWorking = false;
+        temperature = baseTemperature;
     }
 
     public String getCrucibleUIKey() {
@@ -140,10 +142,7 @@ public class StarTHellForgeMachine extends WorkableElectricMultiblockMachine imp
     @Override
     public void onLoad() {
         super.onLoad();
-
-        if (getLevel().isClientSide)
-            return;
-
+        if (isRemote()) return;
         tryTickSub = subscribeServerTick(tryTickSub, this::tryRemoveHeat);
     }
 


### PR DESCRIPTION
* Hellforge now resets heat after being formed or unformed, the spatial IO cheese now requires you to banish the full structure.
* Dreamlink covers can no longer be added to multiblock parts, multiblock controllers, or machines that don't have energy traits.
